### PR TITLE
Issu 14: Add NumPy Information Map to archive repository

### DIFF
--- a/content/numpy_info_map.md
+++ b/content/numpy_info_map.md
@@ -1,17 +1,14 @@
 # NumPy Information Map
 
 ## Objective
-=========
 
 There is loads of information about NumPy scattered across various sites, documents and articles besides several others that are created by the community at large. Our objective is to augment the ongoing NumPy website and documentation spruce-up efforts, through classification of key information related to NumPy. This will help in identifying inconsistencies, gaps and missing pieces that could be addressed as part of NumPy documentation (GSoD, others) and marketing, funding and other related initiatives. The eventual goal is to accelerate the process of on-boarding new NumPy users and make it easy for seasoned users to access relevant information about NumPy in crisp, digestible chunks. We plan to create and use NumPy Information Map to meet this objective.
 
 ## What is an Information Map?
-===========================
 
 An information map helps with analysis, organization, and visual presentation of information. It is a way of classifying and organizing information such as concepts, procedures, proposals, manuals such that it is available to the target audience in digestible chunks. An information map enables efficient information access by improving structure and readability. It also provides the much needed focus on target audience or the 'user', especially in the way information is generated, stored and accessed.
 
 ## What problem does it solve?
-===========================
 
 Following is a list of some of the key problems that can be addressed by an information map. For more details on benefits gained by information mapping, see the reference section.
 

--- a/content/numpy_info_map.md
+++ b/content/numpy_info_map.md
@@ -1,0 +1,379 @@
+---
+title: |
+    []{#_2hkaqbnah5sa .anchor}NumPy Information Map
+
+    []{#_nlftfbt0tahu .anchor}
+---
+
+Objective
+=========
+
+There is loads of information about NumPy scattered across various
+sites, documents and articles besides several others that are created by
+the community at large. Our objective is to augment the ongoing NumPy
+website and documentation spruce-up efforts, through classification of
+key information related to NumPy. This will help in identifying
+inconsistencies, gaps and missing pieces that could be addressed as part
+of NumPy documentation (GSoD, others) and marketing, funding and other
+related initiatives. The eventual goal is to accelerate the process of
+on-boarding new NumPy users and make it easy for seasoned users to
+access relevant information about NumPy in crisp, digestible chunks. We
+plan to create and use NumPy Information Map to meet this objective.
+
+What is an information Map?
+===========================
+
+An information map helps with analysis, organization, and visual
+presentation of information. It is a way of classifying and organizing
+information such as concepts, procedures, proposals, manuals such that
+it is available to the target audience in digestible chunks. An
+information map enables efficient information access by improving
+structure and readability. It also provides the much needed focus on
+target audience or the 'user', especially in the way information is
+generated, stored and accessed.
+
+What problem does it solve?
+===========================
+
+Following is a list of some of the key problems that can be addressed by
+an information map. For more details on benefits gained by information
+mapping, see the reference section.
+
+-   Too long content, TL;DR
+
+-   Un-organized, scattered information in various logical and physical
+    > styles
+
+-   Hard to read and find information about the topic users are
+    > typically interested in
+
+-   Information inconsistencies and gaps
+
+-   Time to completion of tasks takes longer due to information gaps,
+    > hard to locate data
+
+-   Higher costs, lower productivity, expensive errors due to
+    > miscommunication and incorrect information
+
+-   ~~Regulatory and compliance risk factors are higher in case of some
+    > corporations with stringent legal and corporate liabilities~~
+
+NumPy Information Map (Classification Chart)
+============================================
+
+Here is an early draft of the NumPy information map:
+
++-----------------+-----------------+-----------------+-----------------+
+| **Information   | **What it       | **Key           | **Examples with |
+| Type**          | contains?**     | information     | a focus on      |
+|                 |                 | blocks**        | target          |
+|                 |                 |                 | audience**      |
++=================+=================+=================+=================+
+| NumPy Concepts  | Relationships,  | 1.  Names /     |                 |
+|                 | key terms,      |     > Definitio |                 |
+|                 | definitions,    | ns              |                 |
+|                 | usage related   |                 |                 |
+|                 | ideas           | 2.  Rules       |                 |
+|                 |                 |                 |                 |
+|                 |                 | 3.  Introductio |                 |
+|                 |                 | ns              |                 |
+|                 |                 |                 |                 |
+|                 |                 | 4.  Examples    |                 |
+|                 |                 |                 |                 |
+|                 |                 | 5.  Diagrams    |                 |
+|                 |                 |                 |                 |
+|                 |                 | 6.  Syntax      |                 |
+|                 |                 |                 |                 |
+|                 |                 | 7.  Flow charts |                 |
+|                 |                 |                 |                 |
+|                 |                 | 8.  Related     |                 |
+|                 |                 |     > infomap   |                 |
++-----------------+-----------------+-----------------+-----------------+
+| NumPy Structure | Key components  | Physical as     | NumPy SW        |
+|                 | of NumPy and    | well as logical | Components      |
+|                 | how they work   | components with |                 |
+|                 | together        | parts and       | NumPy Code      |
+|                 |                 | distinct        | Components      |
+|                 | Both - for end  | boundaries.     |                 |
+|                 | user (binaries, |                 | NumPy           |
+|                 | libraries,      |                 | History/Evoluti |
+|                 | scripts,        |                 | on/About        |
+|                 | command         |                 |                 |
+|                 | references      |                 | -   NumPy       |
+|                 | etc.) and for   |                 |     > Release   |
+|                 | NumPy           |                 |     > and       |
+|                 | Developers - in |                 |     > feature   |
+|                 | terms of how    |                 |     > timeline  |
+|                 | code is         |                 |                 |
+|                 | organized,      |                 | NumPy Org       |
+|                 | control flows,  |                 | Components      |
+|                 | deployment      |                 |                 |
+|                 | related         |                 | -   [[Steering  |
+|                 | structures      |                 |     > Councils  |
+|                 |                 |                 |     > &         |
+|                 | \*This could    |                 |     > Partners] |
+|                 | also include    |                 | {.underline}](h |
+|                 | NumPy org       |                 | ttps://numpy.or |
+|                 | structure (if   |                 | g/devdocs/dev/g |
+|                 | it makes sense  |                 | overnance/peopl |
+|                 | to share it     |                 | e.html)         |
+|                 | with users -    |                 |                 |
+|                 | say in About    |                 | -   Link to     |
+|                 | kind of tab on  |                 |     > Teams     |
+|                 | website)        |                 |     > page      |
+|                 |                 |                 |     > (TBD)     |
+|                 |                 |                 |                 |
+|                 |                 |                 |     -   Develop |
+|                 |                 |                 | ment            |
+|                 |                 |                 |         > (Comm |
+|                 |                 |                 | unity+dedicated |
+|                 |                 |                 |         > core) |
+|                 |                 |                 |                 |
+|                 |                 |                 |     -   Packagi |
+|                 |                 |                 | ng              |
+|                 |                 |                 |                 |
+|                 |                 |                 |     -   Learnin |
+|                 |                 |                 | g/Education     |
+|                 |                 |                 |         > (Trai |
+|                 |                 |                 | ning?)          |
+|                 |                 |                 |                 |
+|                 |                 |                 |     -   TechPub |
+|                 |                 |                 | s               |
+|                 |                 |                 |                 |
+|                 |                 |                 |     -   Website |
+|                 |                 |                 |                 |
+|                 |                 |                 |     -   Marketi |
+|                 |                 |                 | ng              |
++-----------------+-----------------+-----------------+-----------------+
+| NumPy Processes | Mostly recipes  | 1.  Name        | [For NumPy      |
+|                 | which have a    |                 | Users]{.underli |
+|                 | finite timeline | 2.  Stages      | ne}             |
+|                 | and address     |                 |                 |
+|                 | how-to-do-so-an | 3.  Steps       | -   [[NumPy     |
+|                 | d-so            |                 |     > incident  |
+|                 | with NumPy or   | 4.  I/O         |     > reporting |
+|                 | how to          |                 |     > guideline |
+|                 | contribute to   | 5.  Pre-requisi | s]{.underline}] |
+|                 | NumPy           | tes             | (https://numpy. |
+|                 |                 |     > (Both in  | org/devdocs/dev |
+|                 |                 |     > terms of  | /conduct/code_o |
+|                 |                 |     > other     | f_conduct.html# |
+|                 |                 |     > dependenc | reporting-guide |
+|                 |                 | ies             | lines)          |
+|                 |                 |     > and NumPy |                 |
+|                 |                 |     > usage     | -   Reporting a |
+|                 |                 |     > skills)   |     > bug       |
+|                 |                 |                 |                 |
+|                 |                 | 6.  Cause-Effec | -   Reporting a |
+|                 |                 | t-Procedures    |     > security  |
+|                 |                 |                 |     > issue     |
+|                 |                 |                 |                 |
+|                 |                 |                 | -   Getting     |
+|                 |                 |                 |     > help with |
+|                 |                 |                 |     > NumPy     |
+|                 |                 |                 |     > usage     |
+|                 |                 |                 |                 |
+|                 |                 |                 | [For NumPy      |
+|                 |                 |                 | Contributors &  |
+|                 |                 |                 | Developers]{.un |
+|                 |                 |                 | derline}        |
+|                 |                 |                 |                 |
+|                 |                 |                 | -   [[Contribut |
+|                 |                 |                 | ing             |
+|                 |                 |                 |     > to        |
+|                 |                 |                 |     > NumPy]{.u |
+|                 |                 |                 | nderline}](http |
+|                 |                 |                 | s://numpy.org/d |
+|                 |                 |                 | evdocs/dev/inde |
+|                 |                 |                 | x.html?highligh |
+|                 |                 |                 | t=slack)        |
+|                 |                 |                 |                 |
+|                 |                 |                 |     -   [[Code  |
+|                 |                 |                 |         > of    |
+|                 |                 |                 |         > Condu |
+|                 |                 |                 | ct]{.underline} |
+|                 |                 |                 | ](https://numpy |
+|                 |                 |                 | .org/devdocs/de |
+|                 |                 |                 | v/conduct/code_ |
+|                 |                 |                 | of_conduct.html |
+|                 |                 |                 | )               |
+|                 |                 |                 |                 |
+|                 |                 |                 |     -   [[Devel |
+|                 |                 |                 | oper            |
+|                 |                 |                 |         > Guide |
+|                 |                 |                 | lines]{.underli |
+|                 |                 |                 | ne}](https://nu |
+|                 |                 |                 | mpy.org/devdocs |
+|                 |                 |                 | /dev/gitwash/in |
+|                 |                 |                 | dex.html)       |
+|                 |                 |                 |         > and   |
+|                 |                 |                 |         > [[dev |
+|                 |                 |                 |         > envir |
+|                 |                 |                 | onment          |
+|                 |                 |                 |         > setup |
+|                 |                 |                 | ]{.underline}]( |
+|                 |                 |                 | https://numpy.o |
+|                 |                 |                 | rg/devdocs/dev/ |
+|                 |                 |                 | development_env |
+|                 |                 |                 | ironment.html)  |
+|                 |                 |                 |                 |
+|                 |                 |                 |     -   [[Devel |
+|                 |                 |                 | oper            |
+|                 |                 |                 |         > Workf |
+|                 |                 |                 | low]{.underline |
+|                 |                 |                 | }](https://nump |
+|                 |                 |                 | y.org/devdocs/d |
+|                 |                 |                 | ev/development_ |
+|                 |                 |                 | workflow.html)  |
+|                 |                 |                 |                 |
+|                 |                 |                 |     -   [[C     |
+|                 |                 |                 |         > Style |
+|                 |                 |                 |         > Guide |
+|                 |                 |                 |         > for   |
+|                 |                 |                 |         > NumPy |
+|                 |                 |                 | ]{.underline}]( |
+|                 |                 |                 | https://numpy.o |
+|                 |                 |                 | rg/devdocs/dev/ |
+|                 |                 |                 | style_guide.htm |
+|                 |                 |                 | l)              |
+|                 |                 |                 |                 |
+|                 |                 |                 |     -   [[NumPy |
+|                 |                 |                 |         > Bench |
+|                 |                 |                 | marking]{.under |
+|                 |                 |                 | line}](https:// |
+|                 |                 |                 | numpy.org/devdo |
+|                 |                 |                 | cs/benchmarking |
+|                 |                 |                 | .html)          |
+|                 |                 |                 |                 |
+|                 |                 |                 |     -   [[How   |
+|                 |                 |                 |         > to    |
+|                 |                 |                 |         > relea |
+|                 |                 |                 | se              |
+|                 |                 |                 |         > a     |
+|                 |                 |                 |         > NumPy |
+|                 |                 |                 |         > versi |
+|                 |                 |                 | on]{.underline} |
+|                 |                 |                 | ](https://numpy |
+|                 |                 |                 | .org/devdocs/de |
+|                 |                 |                 | v/releasing.htm |
+|                 |                 |                 | l)              |
+|                 |                 |                 |                 |
+|                 |                 |                 | -   Others TBD  |
++-----------------+-----------------+-----------------+-----------------+
+| NumPy Reference | Functions,      | Name            | Links to User   |
+|                 |                 |                 | guide           |
+|                 | APIs            | I/O             |                 |
+|                 |                 |                 | FAQ             |
+|                 | Others for end  | Usage Model,    |                 |
+|                 | users           | workflow        |                 |
+|                 |                 |                 |                 |
+|                 | Tutorials       | Example code    |                 |
+|                 |                 |                 |                 |
+|                 | Presentations   |                 |                 |
+|                 |                 |                 |                 |
+|                 | Workshops -     |                 |                 |
+|                 | media,          |                 |                 |
+|                 | recordings      |                 |                 |
+|                 | (latest ones)   |                 |                 |
++-----------------+-----------------+-----------------+-----------------+
+| NumPy Showcase  | Case Studies    | 1.  Challenges  |                 |
+|                 |                 |     > before    |                 |
+|                 |                 |     > NumPy,    |                 |
+|                 |                 |                 |                 |
+|                 |                 | 2.  How NumPy   |                 |
+|                 |                 |     > use       |                 |
+|                 |                 |     > helped,   |                 |
+|                 |                 |                 |                 |
+|                 |                 | 3.  Use         |                 |
+|                 |                 |     > Model,Int |                 |
+|                 |                 | eresting        |                 |
+|                 |                 |     > statistic |                 |
+|                 |                 | s               |                 |
+|                 |                 |     > such as   |                 |
+|                 |                 |     > time      |                 |
+|                 |                 |     > reduction |                 |
+|                 |                 |     > for       |                 |
+|                 |                 |     > processin |                 |
+|                 |                 | g               |                 |
+|                 |                 |     > image by  |                 |
+|                 |                 |     > 50% etc., |                 |
+|                 |                 |                 |                 |
+|                 |                 | 4.  Distinctive |                 |
+|                 |                 |     > NumPy use |                 |
+|                 |                 |     > model say |                 |
+|                 |                 |     > in terms  |                 |
+|                 |                 |     > of scale  |                 |
+|                 |                 |     > or type   |                 |
+|                 |                 |     > of usage. |                 |
++-----------------+-----------------+-----------------+-----------------+
+| NumPy Branding  | Logos,          | 1.  Infographic | -   [[Icons]{.u |
+|                 | templates for   | s               | nderline}](http |
+|                 | docs,           |                 | s://github.com/ |
+|                 | proposals,      | 2.  Logos       | numpy/numpy/tre |
+|                 | presentations,  |                 | e/master/brandi |
+|                 | keynotes,       | 3.  Themes      | ng/icons)       |
+|                 | talks, badges   |                 |                 |
+|                 | (For Projects   | 4.  Color-font- | -   [[Color-sch |
+|                 | using NumPy?)   | styling         | eme]{.underline |
+|                 |                 |                 | }](https://user |
+|                 |                 | 5.  Name-recall | -images.githubu |
+|                 |                 |                 | sercontent.com/ |
+|                 |                 |                 | 98330/63642399- |
+|                 |                 |                 | 51f41480-c673-1 |
+|                 |                 |                 | 1e9-8d22-20315b |
+|                 |                 |                 | 71c83e.jpg)     |
+|                 |                 |                 |                 |
+|                 |                 |                 | -               |
++-----------------+-----------------+-----------------+-----------------+
+| Misc (For NumPy | Could include   | 1.  How-to      | -   [[NumPy     |
+| internal use?)  | internal NumPy  |                 |     > Governanc |
+|                 | processes such  | 2.  Steps for   | e]{.underline}] |
+|                 | as governance   |     > NumPy     | (https://numpy. |
+|                 | or output of    |     > governanc | org/devdocs/dev |
+|                 | those processes | e               | /governance/gov |
+|                 | such as         |     > procedure | ernance.html)   |
+|                 | reports,        |     > say xyz   |                 |
+|                 | meeting minutes |                 | -   [[Reports]{ |
+|                 |                 | 3.  Reports     | .underline}](ht |
+|                 |                 |                 | tps://github.co |
+|                 |                 | 4.  Plans       | m/numpy/archive |
+|                 |                 |                 | /tree/master/re |
+|                 |                 |                 | ports)          |
+|                 |                 |                 |                 |
+|                 |                 |                 | -   [[Meeting   |
+|                 |                 |                 |     > minutes]{ |
+|                 |                 |                 | .underline}](ht |
+|                 |                 |                 | tps://github.co |
+|                 |                 |                 | m/numpy/archive |
+|                 |                 |                 | /tree/master/st |
+|                 |                 |                 | atus_meetings)  |
++-----------------+-----------------+-----------------+-----------------+
+| Archives        | This could      | 1.  Mailing     |                 |
+|                 | include         |     > lists     |                 |
+|                 | resources that  |     > archives  |                 |
+|                 | are dated but   |                 |                 |
+|                 | maybe useful    | 2.  StackExchan |                 |
+|                 | for new users   | ge              |                 |
+|                 | or historical   |     > (older    |                 |
+|                 | purposes        |     > discussio |                 |
+|                 |                 | ns              |                 |
+|                 |                 |     > that are  |                 |
+|                 |                 |     > relevant  |                 |
+|                 |                 |     > even      |                 |
+|                 |                 |     > today)    |                 |
+|                 |                 |                 |                 |
+|                 |                 | 3.  Key         |                 |
+|                 |                 |     > decisions |                 |
+|                 |                 |     > and       |                 |
+|                 |                 |     > reasons   |                 |
+|                 |                 |                 |                 |
+|                 |                 | 4.              |                 |
++-----------------+-----------------+-----------------+-----------------+
+
+References
+
+1.  [[http://www.web.stanford.edu/\~rhorn/a/topic/stwrtng\_infomap/artclInfoMappingTraining.pdf]{.underline}](http://www.web.stanford.edu/~rhorn/a/topic/stwrtng_infomap/artclInfoMappingTraining.pdf)
+
+2.  [[https://www.researchgate.net/figure/Example-of-an-information-map\_fig1\_232477925]{.underline}](https://www.researchgate.net/figure/Example-of-an-information-map_fig1_232477925)
+
+3.  [[https://stc-techedit.org/tiki-index.php?page=Evaluating+the+Information+Mapping+Method]{.underline}](https://stc-techedit.org/tiki-index.php?page=Evaluating+the+Information+Mapping+Method)

--- a/content/numpy_info_map.md
+++ b/content/numpy_info_map.md
@@ -1,67 +1,40 @@
----
-title: |
-    []{#_2hkaqbnah5sa .anchor}NumPy Information Map
-
-    []{#_nlftfbt0tahu .anchor}
----
+# NumPy Information Map
 
 Objective
 =========
 
-There is loads of information about NumPy scattered across various
-sites, documents and articles besides several others that are created by
-the community at large. Our objective is to augment the ongoing NumPy
-website and documentation spruce-up efforts, through classification of
-key information related to NumPy. This will help in identifying
-inconsistencies, gaps and missing pieces that could be addressed as part
-of NumPy documentation (GSoD, others) and marketing, funding and other
-related initiatives. The eventual goal is to accelerate the process of
-on-boarding new NumPy users and make it easy for seasoned users to
-access relevant information about NumPy in crisp, digestible chunks. We
-plan to create and use NumPy Information Map to meet this objective.
+There is loads of information about NumPy scattered across various sites, documents and articles besides several others that are created by the community at large. Our objective is to augment the ongoing NumPy website and documentation spruce-up efforts, through classification of key information related to NumPy. This will help in identifying inconsistencies, gaps and missing pieces that could be addressed as part of NumPy documentation (GSoD, others) and marketing, funding and other related initiatives. The eventual goal is to accelerate the process of on-boarding new NumPy users and make it easy for seasoned users to access relevant information about NumPy in crisp, digestible chunks. We plan to create and use NumPy Information Map to meet this objective.
 
 What is an information Map?
 ===========================
 
-An information map helps with analysis, organization, and visual
-presentation of information. It is a way of classifying and organizing
-information such as concepts, procedures, proposals, manuals such that
-it is available to the target audience in digestible chunks. An
-information map enables efficient information access by improving
-structure and readability. It also provides the much needed focus on
-target audience or the 'user', especially in the way information is
-generated, stored and accessed.
+An information map helps with analysis, organization, and visual presentation of information. It is a way of classifying and organizing information such as concepts, procedures, proposals, manuals such that it is available to the target audience in digestible chunks. An information map enables efficient information access by improving structure and readability. It also provides the much needed focus on target audience or the 'user', especially in the way information is generated, stored and accessed.
 
 What problem does it solve?
 ===========================
 
-Following is a list of some of the key problems that can be addressed by
-an information map. For more details on benefits gained by information
-mapping, see the reference section.
+Following is a list of some of the key problems that can be addressed by an information map. For more details on benefits gained by information mapping, see the reference section.
 
 -   Too long content, TL;DR
 
--   Un-organized, scattered information in various logical and physical
-    > styles
+-   Un-organized, scattered information in various logical and physical styles
 
--   Hard to read and find information about the topic users are
-    > typically interested in
+-   Hard to read and find information about the topic users are typically interested in
 
 -   Information inconsistencies and gaps
 
--   Time to completion of tasks takes longer due to information gaps,
-    > hard to locate data
+-   Time to completion of tasks takes longer due to information gaps, hard to locate data
 
--   Higher costs, lower productivity, expensive errors due to
-    > miscommunication and incorrect information
-
--   ~~Regulatory and compliance risk factors are higher in case of some
-    > corporations with stringent legal and corporate liabilities~~
+-   Higher costs, lower productivity, expensive errors due to miscommunication and incorrect information
 
 NumPy Information Map (Classification Chart)
 ============================================
 
 Here is an early draft of the NumPy information map:
+
+|  Information    | What it         | 
+| ----------------|-----------------|
+| some text       |  **bold text**  |
 
 +-----------------+-----------------+-----------------+-----------------+
 | **Information   | **What it       | **Key           | **Examples with |

--- a/content/numpy_info_map.md
+++ b/content/numpy_info_map.md
@@ -32,37 +32,15 @@ NumPy Information Map (Classification Chart)
 
 Here is an early draft of the NumPy information map:
 
-|  Information    | What it         | 
-| ----------------|-----------------|
-| some text       |  **bold text**  |
 
-+-----------------+-----------------+-----------------+-----------------+
-| **Information   | **What it       | **Key           | **Examples with |
-| Type**          | contains?**     | information     | a focus on      |
-|                 |                 | blocks**        | target          |
-|                 |                 |                 | audience**      |
-+=================+=================+=================+=================+
-| NumPy Concepts  | Relationships,  | 1.  Names /     |                 |
-|                 | key terms,      |     > Definitio |                 |
-|                 | definitions,    | ns              |                 |
-|                 | usage related   |                 |                 |
-|                 | ideas           | 2.  Rules       |                 |
-|                 |                 |                 |                 |
-|                 |                 | 3.  Introductio |                 |
-|                 |                 | ns              |                 |
-|                 |                 |                 |                 |
-|                 |                 | 4.  Examples    |                 |
-|                 |                 |                 |                 |
-|                 |                 | 5.  Diagrams    |                 |
-|                 |                 |                 |                 |
-|                 |                 | 6.  Syntax      |                 |
-|                 |                 |                 |                 |
-|                 |                 | 7.  Flow charts |                 |
-|                 |                 |                 |                 |
-|                 |                 | 8.  Related     |                 |
-|                 |                 |     > infomap   |                 |
-+-----------------+-----------------+-----------------+-----------------+
-| NumPy Structure | Key components  | Physical as     | NumPy SW        |
+|** Information Type** 	| **What it contains?** | **Key information blocks**	| **Examples with a focus on target audience** 	|
+|:-------	|:----------	|:--------	|:---------	|
+| NumPy Concepts | Relationships, key terms, definitions, usage related ideas 	|* Names / Definitions<br>* Rules<br>* Introductions<br>* Examples<br>* Diagrams<br>* Syntax<br>* Flow charts<br>Related infomap| |
+| NumPy Structure | Key components of NumPy and how they work together<br><br>Both - for end user (binaries, libraries, scripts, command references etc.) and for NumPy Developers - in terms of how code is organized, control flows, deployment related structures<br><br>*This could also include NumPy org structure (if it makes sense to share it with users - say in About kind of tab on website)|Physical as well as logical components with parts and distinct boundaries.|NumPy SW Components<br><br>NumPy Code Components<br><br>NumPy History/Evolution/About<br><br> * NumPy Release and feature timeline<br><br>NumPy Org Components<br> * Steering Councils & Partners<br> * Link to Teams page (TBD)<br><br>   -Development (Community+dedicated core)<br>   - Packaging<br>   - Learning/Education (Training?)<br>  - TechPubs<br>  - Website<br>   - Marketing |
+
+
+
+| Physical as     | NumPy SW        |
 |                 | of NumPy and    | well as logical | Components      |
 |                 | how they work   | components with |                 |
 |                 | together        | parts and       | NumPy Code      |

--- a/content/numpy_info_map.md
+++ b/content/numpy_info_map.md
@@ -1,16 +1,16 @@
 # NumPy Information Map
 
-Objective
+## Objective
 =========
 
 There is loads of information about NumPy scattered across various sites, documents and articles besides several others that are created by the community at large. Our objective is to augment the ongoing NumPy website and documentation spruce-up efforts, through classification of key information related to NumPy. This will help in identifying inconsistencies, gaps and missing pieces that could be addressed as part of NumPy documentation (GSoD, others) and marketing, funding and other related initiatives. The eventual goal is to accelerate the process of on-boarding new NumPy users and make it easy for seasoned users to access relevant information about NumPy in crisp, digestible chunks. We plan to create and use NumPy Information Map to meet this objective.
 
-What is an information Map?
+## What is an Information Map?
 ===========================
 
 An information map helps with analysis, organization, and visual presentation of information. It is a way of classifying and organizing information such as concepts, procedures, proposals, manuals such that it is available to the target audience in digestible chunks. An information map enables efficient information access by improving structure and readability. It also provides the much needed focus on target audience or the 'user', especially in the way information is generated, stored and accessed.
 
-What problem does it solve?
+## What problem does it solve?
 ===========================
 
 Following is a list of some of the key problems that can be addressed by an information map. For more details on benefits gained by information mapping, see the reference section.
@@ -27,304 +27,26 @@ Following is a list of some of the key problems that can be addressed by an info
 
 -   Higher costs, lower productivity, expensive errors due to miscommunication and incorrect information
 
-NumPy Information Map (Classification Chart)
-============================================
+## NumPy Information Map (Classification Chart)
 
 Here is an early draft of the NumPy information map:
 
 
-|** Information Type** 	| **What it contains?** | **Key information blocks**	| **Examples with a focus on target audience** 	|
+| Information Type 	| What it contains? | Key information blocks	| Examples with a focus on target audience 	|
 |:-------	|:----------	|:--------	|:---------	|
-| NumPy Concepts | Relationships, key terms, definitions, usage related ideas 	|* Names / Definitions<br>* Rules<br>* Introductions<br>* Examples<br>* Diagrams<br>* Syntax<br>* Flow charts<br>Related infomap| |
-| NumPy Structure | Key components of NumPy and how they work together<br><br>Both - for end user (binaries, libraries, scripts, command references etc.) and for NumPy Developers - in terms of how code is organized, control flows, deployment related structures<br><br>*This could also include NumPy org structure (if it makes sense to share it with users - say in About kind of tab on website)|Physical as well as logical components with parts and distinct boundaries.|NumPy SW Components<br><br>NumPy Code Components<br><br>NumPy History/Evolution/About<br><br> * NumPy Release and feature timeline<br><br>NumPy Org Components<br> * Steering Councils & Partners<br> * Link to Teams page (TBD)<br><br>   -Development (Community+dedicated core)<br>   - Packaging<br>   - Learning/Education (Training?)<br>  - TechPubs<br>  - Website<br>   - Marketing |
+| NumPy Concepts | Relationships, key terms, definitions, usage related ideas 	|* Names / Definitions<br>* Rules<br> * Introductions <br>* Examples<br>* Diagrams<br>* Syntax<br> * Flow charts<br>Related infomap| |
+| NumPy Structure | Key components of NumPy and how they work together<br><br>Both - for end user (binaries, libraries, scripts, command references etc.) and for NumPy Developers - in terms of how code is organized, control flows, deployment related structures<br><br>*This could also include NumPy org structure (if it makes sense to share it with users - say in About kind of tab on website)|Physical as well as logical components with parts and distinct boundaries.|NumPy SW Components<br><br>NumPy Code Components<br><br>NumPy History/Evolution/About<br><br> * NumPy Release and feature timeline<br><br>NumPy Org Components<br> * [Steering Councils & Partners](https://numpy.org/devdocs/dev/governance/people.html)<br> * Link to Teams page (TBD)<br><br>   - Development (Community+dedicated core)<br>   - Packaging<br>   - Learning/Education (Training?)<br>  - TechPubs<br>  - Website<br>   - Marketing |
+|NumPy Processes|Mostly recipes which have a finite timeline and address how-to-do-so-and-so with NumPy or how to contribute to NumPy<br><br>|* Name<br>* Stages<br>* Steps<br>* I/O<br>* Pre-requisites (Both in terms of other dependencies and NumPy usage skills)<br>* Cause-Effect-Procedures| 1. _For NumPy Users_ <br><br> * [NumPy incident reporting guidelines](https://numpy.org/devdocs/dev/conduct/code_of_conduct.html#reporting-guidelines)<br> * Reporting a bug<br> * Reporting a security issue<br> * Getting help with NumPy usage<br><br> 2. _For NumPy Contributors & Developers_ <br><br> a.) [Contributing to NumPy](https://numpy.org/devdocs/dev/index.html?highlight=slack)<br>- [Code of Conduct](https://numpy.org/devdocs/dev/conduct/code_of_conduct.html) <br>- [Developer Guidelines and dev environment setup](https://numpy.org/devdocs/dev/gitwash/index.html)<br>- [Developer Workflow](https://numpy.org/devdocs/dev/development_workflow.html)<br>- [C Style Guide for NumPy](https://numpy.org/devdocs/dev/style_guide.html)<br>- [NumPy Benchmarking](https://numpy.org/devdocs/benchmarking.html)<br>- [How to release a NumPy version](https://numpy.org/devdocs/dev/releasing.html)<br><br> b.) Others TBD|
+|NumPy Reference| Functions,APIs meant for end users, Tutorials, Presentations, Workshops - media, recordings (latest ones)|* Name<br>* I/O<br>* Usage Model, workflow<br>* Example code|* Links to User guide<br>* FAQ|
+|NumPy Showcase|Case Studies|* Challenges faced before NumPy was adopted,<br> * How NumPy use helped,<br> * Use Model,Interesting statistics such as time reduction for processing image by 50% etc.,<br> * Distinctive NumPy use model say in terms of scale or type of usage.|Marquee Case Studies such as:<br><br>1. First Black Hole Image<br>2. LIGO - Gravitational Waves Detection and reporting in real time<br> 3. NumPy in Sports data analytics (Maybe)|
+|NumPy Branding|Logos, templates for docs, proposals, presentations, keynotes, talks, badges (For Projects using NumPy?)|* Infographics<br> * Logos<br> * Themes<br> * Color-font-styling<br> * Name-recall|1. [Icons](https://github.com/numpy/numpy/tree/master/branding/icons)<br>2. [Color-scheme](https://user-images.githubusercontent.com/98330/63642399-51f41480-c673-11e9-8d22-20315b71c83e.jpg)|
+|Misc (For NumPy internal use?)|This could include internal NumPy processes such as governance or output of those processes such as reports, meeting minutes|1. How-to (some NumPy internal process)<br>2. Steps for NumPy governance procedure say xyz<br>3. Reports<br>4.Plans| [NumPy Governance](https://numpy.org/devdocs/dev/governance/governance.html)<br>[Reports](https://github.com/numpy/archive/tree/master/reports)<br>[Meeting minutes](https://github.com/numpy/archive/tree/master/status_meetings)|
+|Archives|This could include resources that are dated but maybe useful for new users or historical purposes|* Mailing lists archives<br>* StackExchange (older discussions that are relevant even today)<br>* Key decisions and reasons|TBD|
 
+## References
 
+1.  [Information Mapping](http://www.web.stanford.edu/\~rhorn/a/topicstwrtng\_infomap/artclInfoMappingTraining.pdf)
 
-| Physical as     | NumPy SW        |
-|                 | of NumPy and    | well as logical | Components      |
-|                 | how they work   | components with |                 |
-|                 | together        | parts and       | NumPy Code      |
-|                 |                 | distinct        | Components      |
-|                 | Both - for end  | boundaries.     |                 |
-|                 | user (binaries, |                 | NumPy           |
-|                 | libraries,      |                 | History/Evoluti |
-|                 | scripts,        |                 | on/About        |
-|                 | command         |                 |                 |
-|                 | references      |                 | -   NumPy       |
-|                 | etc.) and for   |                 |     > Release   |
-|                 | NumPy           |                 |     > and       |
-|                 | Developers - in |                 |     > feature   |
-|                 | terms of how    |                 |     > timeline  |
-|                 | code is         |                 |                 |
-|                 | organized,      |                 | NumPy Org       |
-|                 | control flows,  |                 | Components      |
-|                 | deployment      |                 |                 |
-|                 | related         |                 | -   [[Steering  |
-|                 | structures      |                 |     > Councils  |
-|                 |                 |                 |     > &         |
-|                 | \*This could    |                 |     > Partners] |
-|                 | also include    |                 | {.underline}](h |
-|                 | NumPy org       |                 | ttps://numpy.or |
-|                 | structure (if   |                 | g/devdocs/dev/g |
-|                 | it makes sense  |                 | overnance/peopl |
-|                 | to share it     |                 | e.html)         |
-|                 | with users -    |                 |                 |
-|                 | say in About    |                 | -   Link to     |
-|                 | kind of tab on  |                 |     > Teams     |
-|                 | website)        |                 |     > page      |
-|                 |                 |                 |     > (TBD)     |
-|                 |                 |                 |                 |
-|                 |                 |                 |     -   Develop |
-|                 |                 |                 | ment            |
-|                 |                 |                 |         > (Comm |
-|                 |                 |                 | unity+dedicated |
-|                 |                 |                 |         > core) |
-|                 |                 |                 |                 |
-|                 |                 |                 |     -   Packagi |
-|                 |                 |                 | ng              |
-|                 |                 |                 |                 |
-|                 |                 |                 |     -   Learnin |
-|                 |                 |                 | g/Education     |
-|                 |                 |                 |         > (Trai |
-|                 |                 |                 | ning?)          |
-|                 |                 |                 |                 |
-|                 |                 |                 |     -   TechPub |
-|                 |                 |                 | s               |
-|                 |                 |                 |                 |
-|                 |                 |                 |     -   Website |
-|                 |                 |                 |                 |
-|                 |                 |                 |     -   Marketi |
-|                 |                 |                 | ng              |
-+-----------------+-----------------+-----------------+-----------------+
-| NumPy Processes | Mostly recipes  | 1.  Name        | [For NumPy      |
-|                 | which have a    |                 | Users]{.underli |
-|                 | finite timeline | 2.  Stages      | ne}             |
-|                 | and address     |                 |                 |
-|                 | how-to-do-so-an | 3.  Steps       | -   [[NumPy     |
-|                 | d-so            |                 |     > incident  |
-|                 | with NumPy or   | 4.  I/O         |     > reporting |
-|                 | how to          |                 |     > guideline |
-|                 | contribute to   | 5.  Pre-requisi | s]{.underline}] |
-|                 | NumPy           | tes             | (https://numpy. |
-|                 |                 |     > (Both in  | org/devdocs/dev |
-|                 |                 |     > terms of  | /conduct/code_o |
-|                 |                 |     > other     | f_conduct.html# |
-|                 |                 |     > dependenc | reporting-guide |
-|                 |                 | ies             | lines)          |
-|                 |                 |     > and NumPy |                 |
-|                 |                 |     > usage     | -   Reporting a |
-|                 |                 |     > skills)   |     > bug       |
-|                 |                 |                 |                 |
-|                 |                 | 6.  Cause-Effec | -   Reporting a |
-|                 |                 | t-Procedures    |     > security  |
-|                 |                 |                 |     > issue     |
-|                 |                 |                 |                 |
-|                 |                 |                 | -   Getting     |
-|                 |                 |                 |     > help with |
-|                 |                 |                 |     > NumPy     |
-|                 |                 |                 |     > usage     |
-|                 |                 |                 |                 |
-|                 |                 |                 | [For NumPy      |
-|                 |                 |                 | Contributors &  |
-|                 |                 |                 | Developers]{.un |
-|                 |                 |                 | derline}        |
-|                 |                 |                 |                 |
-|                 |                 |                 | -   [[Contribut |
-|                 |                 |                 | ing             |
-|                 |                 |                 |     > to        |
-|                 |                 |                 |     > NumPy]{.u |
-|                 |                 |                 | nderline}](http |
-|                 |                 |                 | s://numpy.org/d |
-|                 |                 |                 | evdocs/dev/inde |
-|                 |                 |                 | x.html?highligh |
-|                 |                 |                 | t=slack)        |
-|                 |                 |                 |                 |
-|                 |                 |                 |     -   [[Code  |
-|                 |                 |                 |         > of    |
-|                 |                 |                 |         > Condu |
-|                 |                 |                 | ct]{.underline} |
-|                 |                 |                 | ](https://numpy |
-|                 |                 |                 | .org/devdocs/de |
-|                 |                 |                 | v/conduct/code_ |
-|                 |                 |                 | of_conduct.html |
-|                 |                 |                 | )               |
-|                 |                 |                 |                 |
-|                 |                 |                 |     -   [[Devel |
-|                 |                 |                 | oper            |
-|                 |                 |                 |         > Guide |
-|                 |                 |                 | lines]{.underli |
-|                 |                 |                 | ne}](https://nu |
-|                 |                 |                 | mpy.org/devdocs |
-|                 |                 |                 | /dev/gitwash/in |
-|                 |                 |                 | dex.html)       |
-|                 |                 |                 |         > and   |
-|                 |                 |                 |         > [[dev |
-|                 |                 |                 |         > envir |
-|                 |                 |                 | onment          |
-|                 |                 |                 |         > setup |
-|                 |                 |                 | ]{.underline}]( |
-|                 |                 |                 | https://numpy.o |
-|                 |                 |                 | rg/devdocs/dev/ |
-|                 |                 |                 | development_env |
-|                 |                 |                 | ironment.html)  |
-|                 |                 |                 |                 |
-|                 |                 |                 |     -   [[Devel |
-|                 |                 |                 | oper            |
-|                 |                 |                 |         > Workf |
-|                 |                 |                 | low]{.underline |
-|                 |                 |                 | }](https://nump |
-|                 |                 |                 | y.org/devdocs/d |
-|                 |                 |                 | ev/development_ |
-|                 |                 |                 | workflow.html)  |
-|                 |                 |                 |                 |
-|                 |                 |                 |     -   [[C     |
-|                 |                 |                 |         > Style |
-|                 |                 |                 |         > Guide |
-|                 |                 |                 |         > for   |
-|                 |                 |                 |         > NumPy |
-|                 |                 |                 | ]{.underline}]( |
-|                 |                 |                 | https://numpy.o |
-|                 |                 |                 | rg/devdocs/dev/ |
-|                 |                 |                 | style_guide.htm |
-|                 |                 |                 | l)              |
-|                 |                 |                 |                 |
-|                 |                 |                 |     -   [[NumPy |
-|                 |                 |                 |         > Bench |
-|                 |                 |                 | marking]{.under |
-|                 |                 |                 | line}](https:// |
-|                 |                 |                 | numpy.org/devdo |
-|                 |                 |                 | cs/benchmarking |
-|                 |                 |                 | .html)          |
-|                 |                 |                 |                 |
-|                 |                 |                 |     -   [[How   |
-|                 |                 |                 |         > to    |
-|                 |                 |                 |         > relea |
-|                 |                 |                 | se              |
-|                 |                 |                 |         > a     |
-|                 |                 |                 |         > NumPy |
-|                 |                 |                 |         > versi |
-|                 |                 |                 | on]{.underline} |
-|                 |                 |                 | ](https://numpy |
-|                 |                 |                 | .org/devdocs/de |
-|                 |                 |                 | v/releasing.htm |
-|                 |                 |                 | l)              |
-|                 |                 |                 |                 |
-|                 |                 |                 | -   Others TBD  |
-+-----------------+-----------------+-----------------+-----------------+
-| NumPy Reference | Functions,      | Name            | Links to User   |
-|                 |                 |                 | guide           |
-|                 | APIs            | I/O             |                 |
-|                 |                 |                 | FAQ             |
-|                 | Others for end  | Usage Model,    |                 |
-|                 | users           | workflow        |                 |
-|                 |                 |                 |                 |
-|                 | Tutorials       | Example code    |                 |
-|                 |                 |                 |                 |
-|                 | Presentations   |                 |                 |
-|                 |                 |                 |                 |
-|                 | Workshops -     |                 |                 |
-|                 | media,          |                 |                 |
-|                 | recordings      |                 |                 |
-|                 | (latest ones)   |                 |                 |
-+-----------------+-----------------+-----------------+-----------------+
-| NumPy Showcase  | Case Studies    | 1.  Challenges  |                 |
-|                 |                 |     > before    |                 |
-|                 |                 |     > NumPy,    |                 |
-|                 |                 |                 |                 |
-|                 |                 | 2.  How NumPy   |                 |
-|                 |                 |     > use       |                 |
-|                 |                 |     > helped,   |                 |
-|                 |                 |                 |                 |
-|                 |                 | 3.  Use         |                 |
-|                 |                 |     > Model,Int |                 |
-|                 |                 | eresting        |                 |
-|                 |                 |     > statistic |                 |
-|                 |                 | s               |                 |
-|                 |                 |     > such as   |                 |
-|                 |                 |     > time      |                 |
-|                 |                 |     > reduction |                 |
-|                 |                 |     > for       |                 |
-|                 |                 |     > processin |                 |
-|                 |                 | g               |                 |
-|                 |                 |     > image by  |                 |
-|                 |                 |     > 50% etc., |                 |
-|                 |                 |                 |                 |
-|                 |                 | 4.  Distinctive |                 |
-|                 |                 |     > NumPy use |                 |
-|                 |                 |     > model say |                 |
-|                 |                 |     > in terms  |                 |
-|                 |                 |     > of scale  |                 |
-|                 |                 |     > or type   |                 |
-|                 |                 |     > of usage. |                 |
-+-----------------+-----------------+-----------------+-----------------+
-| NumPy Branding  | Logos,          | 1.  Infographic | -   [[Icons]{.u |
-|                 | templates for   | s               | nderline}](http |
-|                 | docs,           |                 | s://github.com/ |
-|                 | proposals,      | 2.  Logos       | numpy/numpy/tre |
-|                 | presentations,  |                 | e/master/brandi |
-|                 | keynotes,       | 3.  Themes      | ng/icons)       |
-|                 | talks, badges   |                 |                 |
-|                 | (For Projects   | 4.  Color-font- | -   [[Color-sch |
-|                 | using NumPy?)   | styling         | eme]{.underline |
-|                 |                 |                 | }](https://user |
-|                 |                 | 5.  Name-recall | -images.githubu |
-|                 |                 |                 | sercontent.com/ |
-|                 |                 |                 | 98330/63642399- |
-|                 |                 |                 | 51f41480-c673-1 |
-|                 |                 |                 | 1e9-8d22-20315b |
-|                 |                 |                 | 71c83e.jpg)     |
-|                 |                 |                 |                 |
-|                 |                 |                 | -               |
-+-----------------+-----------------+-----------------+-----------------+
-| Misc (For NumPy | Could include   | 1.  How-to      | -   [[NumPy     |
-| internal use?)  | internal NumPy  |                 |     > Governanc |
-|                 | processes such  | 2.  Steps for   | e]{.underline}] |
-|                 | as governance   |     > NumPy     | (https://numpy. |
-|                 | or output of    |     > governanc | org/devdocs/dev |
-|                 | those processes | e               | /governance/gov |
-|                 | such as         |     > procedure | ernance.html)   |
-|                 | reports,        |     > say xyz   |                 |
-|                 | meeting minutes |                 | -   [[Reports]{ |
-|                 |                 | 3.  Reports     | .underline}](ht |
-|                 |                 |                 | tps://github.co |
-|                 |                 | 4.  Plans       | m/numpy/archive |
-|                 |                 |                 | /tree/master/re |
-|                 |                 |                 | ports)          |
-|                 |                 |                 |                 |
-|                 |                 |                 | -   [[Meeting   |
-|                 |                 |                 |     > minutes]{ |
-|                 |                 |                 | .underline}](ht |
-|                 |                 |                 | tps://github.co |
-|                 |                 |                 | m/numpy/archive |
-|                 |                 |                 | /tree/master/st |
-|                 |                 |                 | atus_meetings)  |
-+-----------------+-----------------+-----------------+-----------------+
-| Archives        | This could      | 1.  Mailing     |                 |
-|                 | include         |     > lists     |                 |
-|                 | resources that  |     > archives  |                 |
-|                 | are dated but   |                 |                 |
-|                 | maybe useful    | 2.  StackExchan |                 |
-|                 | for new users   | ge              |                 |
-|                 | or historical   |     > (older    |                 |
-|                 | purposes        |     > discussio |                 |
-|                 |                 | ns              |                 |
-|                 |                 |     > that are  |                 |
-|                 |                 |     > relevant  |                 |
-|                 |                 |     > even      |                 |
-|                 |                 |     > today)    |                 |
-|                 |                 |                 |                 |
-|                 |                 | 3.  Key         |                 |
-|                 |                 |     > decisions |                 |
-|                 |                 |     > and       |                 |
-|                 |                 |     > reasons   |                 |
-|                 |                 |                 |                 |
-|                 |                 | 4.              |                 |
-+-----------------+-----------------+-----------------+-----------------+
+2.  [Example of an Information Map](https://www.researchgate.net/figure/Example-of-an-information-map\_fig1\_232477925)
 
-References
-
-1.  [[http://www.web.stanford.edu/\~rhorn/a/topic/stwrtng\_infomap/artclInfoMappingTraining.pdf]{.underline}](http://www.web.stanford.edu/~rhorn/a/topic/stwrtng_infomap/artclInfoMappingTraining.pdf)
-
-2.  [[https://www.researchgate.net/figure/Example-of-an-information-map\_fig1\_232477925]{.underline}](https://www.researchgate.net/figure/Example-of-an-information-map_fig1_232477925)
-
-3.  [[https://stc-techedit.org/tiki-index.php?page=Evaluating+the+Information+Mapping+Method]{.underline}](https://stc-techedit.org/tiki-index.php?page=Evaluating+the+Information+Mapping+Method)
+3.  [Evaluating Information Mapping methods](https://stc-techedit.org/tiki-index.php?page=Evaluating+the+Information+Mapping+Method)


### PR DESCRIPTION
This document was created as part of content initiative for the new NumPy.org website / GSoD discussions regarding giving a structure to all information available for NumPy.  The objective was to collate information such that target audience finds it easier to access relevant info about NumPy.  This is the first draft in markdown format.